### PR TITLE
Basic auth for `/api/v1/list/` endpoint + better code coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/build
     - name: test
-      run: make test
+      run: make testwithcoverage
 
   deploy:
     needs: [lint, test]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ notes.md
 __pycache__/
 *.pyc
 .env
+.coverage
 
 node_modules
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+
+test = poetry run pytest --capture=fd --verbosity=0
+testwithcoverage = $(test) \
+		--cov=app \
+		--cov-report=term-missing:skip-covered \
+		--cov-fail-under=90
+
 dev:
 	fastapi dev app/main.py
 
@@ -16,3 +23,6 @@ fmt:
 
 test:
 	poetry run pytest
+
+testwithcoverage:
+	$(testwithcoverage)

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -3,16 +3,17 @@ from typing import TYPE_CHECKING, Annotated
 
 import botocore
 import botocore.exceptions
-from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_dynamodb.type_defs import ScanOutputTableTypeDef
 
 from app.config import settings
 from app.db import get_db_table
+from app.dependencies import require_basic_auth
 
 router = APIRouter(prefix="/api/v1")
 limiter = Limiter(key_func=get_remote_address)
@@ -49,8 +50,7 @@ async def shorten_url(request: Request, data: Annotated[ShortenUrlForm, Form()])
     }
 
 
-# TODO: should not be public, either remove or add basic auth to view
-@router.get("/list")
+@router.get("/list", dependencies=[Depends(require_basic_auth)])
 async def list_urls() -> dict:
     table = get_db_table()
     response: "ScanOutputTableTypeDef" = table.scan()

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class SettingsMixin:
     @staticmethod
     def parse_comma_separated_values(setting: str | tuple[str, ...]) -> tuple[str, ...]:
-        if isinstance(setting, str):
+        if isinstance(setting, str):  # pragma: no cover
             return tuple(item.strip() for item in setting.split(","))
         return setting
 

--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,11 @@ class DatabaseSettings(BaseSettings):
     aws_region_name: str = Field(default="local")
 
 
+class AuthSettings(BaseSettings):
+    basic_auth_username: str = Field(default="")
+    basic_auth_password: str = Field(default="")
+
+
 class CorsSettings(SettingsMixin, BaseSettings):
     cors_allowed_origins: str | tuple[str, ...] = Field(default=("*",))
     cors_allowed_methods: str | tuple[str, ...] = Field(default=("POST", "GET"))
@@ -30,7 +35,7 @@ class CorsSettings(SettingsMixin, BaseSettings):
         return super().parse_comma_separated_values(setting)
 
 
-class Settings(DatabaseSettings, CorsSettings):
+class Settings(DatabaseSettings, CorsSettings, AuthSettings):
     model_config = SettingsConfigDict(env_file="app/.env", env_file_encoding="utf-8")
 
     debug: bool = Field(default=False)

--- a/app/db.py
+++ b/app/db.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
 from app.config import settings

--- a/app/db.py
+++ b/app/db.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover
 from app.config import settings
 
 
-def get_ddb_resource() -> "DynamoDBServiceResource":
+def get_ddb_resource() -> "DynamoDBServiceResource":  # pragma: no cover
     resource: "DynamoDBServiceResource" = boto3.resource(
         "dynamodb",
         endpoint_url=settings.ddb_endpoint_url,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,22 @@
+import secrets
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from app.config import settings
+
+http_basic_auth = HTTPBasic()
+
+
+def require_basic_auth(credentials: Annotated[HTTPBasicCredentials, Depends(http_basic_auth)]):
+    username, password = credentials.username.encode(), credentials.password.encode()
+    username_valid = secrets.compare_digest(username, settings.basic_auth_username.encode())
+    password_valid = secrets.compare_digest(password, settings.basic_auth_password.encode())
+
+    if not (username_valid and password_valid):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "url-shortener",
   "version": "1.0.0",
   "scripts": {
-    "dev": "BACKEND_PORT=8000 PORT=5555 vite",
+    "dev": "BACKEND_PORT=8080 PORT=5555 vite",
     "build": "tsc && vite build",
     "check:lint": "eslint",
     "check:type": "tsc",

--- a/poetry.lock
+++ b/poetry.lock
@@ -351,6 +351,80 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.4"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "coverage-7.6.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5f8ae553cba74085db385d489c7a792ad66f7f9ba2ee85bfa508aeb84cf0ba07"},
+    {file = "coverage-7.6.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8165b796df0bd42e10527a3f493c592ba494f16ef3c8b531288e3d0d72c1f6f0"},
+    {file = "coverage-7.6.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7c8b95bf47db6d19096a5e052ffca0a05f335bc63cef281a6e8fe864d450a72"},
+    {file = "coverage-7.6.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ed9281d1b52628e81393f5eaee24a45cbd64965f41857559c2b7ff19385df51"},
+    {file = "coverage-7.6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0809082ee480bb8f7416507538243c8863ac74fd8a5d2485c46f0f7499f2b491"},
+    {file = "coverage-7.6.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d541423cdd416b78626b55f123412fcf979d22a2c39fce251b350de38c15c15b"},
+    {file = "coverage-7.6.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:58809e238a8a12a625c70450b48e8767cff9eb67c62e6154a642b21ddf79baea"},
+    {file = "coverage-7.6.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c9b8e184898ed014884ca84c70562b4a82cbc63b044d366fedc68bc2b2f3394a"},
+    {file = "coverage-7.6.4-cp310-cp310-win32.whl", hash = "sha256:6bd818b7ea14bc6e1f06e241e8234508b21edf1b242d49831831a9450e2f35fa"},
+    {file = "coverage-7.6.4-cp310-cp310-win_amd64.whl", hash = "sha256:06babbb8f4e74b063dbaeb74ad68dfce9186c595a15f11f5d5683f748fa1d172"},
+    {file = "coverage-7.6.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:73d2b73584446e66ee633eaad1a56aad577c077f46c35ca3283cd687b7715b0b"},
+    {file = "coverage-7.6.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51b44306032045b383a7a8a2c13878de375117946d68dcb54308111f39775a25"},
+    {file = "coverage-7.6.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b3fb02fe73bed561fa12d279a417b432e5b50fe03e8d663d61b3d5990f29546"},
+    {file = "coverage-7.6.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed8fe9189d2beb6edc14d3ad19800626e1d9f2d975e436f84e19efb7fa19469b"},
+    {file = "coverage-7.6.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b369ead6527d025a0fe7bd3864e46dbee3aa8f652d48df6174f8d0bac9e26e0e"},
+    {file = "coverage-7.6.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ade3ca1e5f0ff46b678b66201f7ff477e8fa11fb537f3b55c3f0568fbfe6e718"},
+    {file = "coverage-7.6.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:27fb4a050aaf18772db513091c9c13f6cb94ed40eacdef8dad8411d92d9992db"},
+    {file = "coverage-7.6.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4f704f0998911abf728a7783799444fcbbe8261c4a6c166f667937ae6a8aa522"},
+    {file = "coverage-7.6.4-cp311-cp311-win32.whl", hash = "sha256:29155cd511ee058e260db648b6182c419422a0d2e9a4fa44501898cf918866cf"},
+    {file = "coverage-7.6.4-cp311-cp311-win_amd64.whl", hash = "sha256:8902dd6a30173d4ef09954bfcb24b5d7b5190cf14a43170e386979651e09ba19"},
+    {file = "coverage-7.6.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12394842a3a8affa3ba62b0d4ab7e9e210c5e366fbac3e8b2a68636fb19892c2"},
+    {file = "coverage-7.6.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b6b4c83d8e8ea79f27ab80778c19bc037759aea298da4b56621f4474ffeb117"},
+    {file = "coverage-7.6.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d5b8007f81b88696d06f7df0cb9af0d3b835fe0c8dbf489bad70b45f0e45613"},
+    {file = "coverage-7.6.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b57b768feb866f44eeed9f46975f3d6406380275c5ddfe22f531a2bf187eda27"},
+    {file = "coverage-7.6.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5915fcdec0e54ee229926868e9b08586376cae1f5faa9bbaf8faf3561b393d52"},
+    {file = "coverage-7.6.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b58c672d14f16ed92a48db984612f5ce3836ae7d72cdd161001cc54512571f2"},
+    {file = "coverage-7.6.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2fdef0d83a2d08d69b1f2210a93c416d54e14d9eb398f6ab2f0a209433db19e1"},
+    {file = "coverage-7.6.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cf717ee42012be8c0cb205dbbf18ffa9003c4cbf4ad078db47b95e10748eec5"},
+    {file = "coverage-7.6.4-cp312-cp312-win32.whl", hash = "sha256:7bb92c539a624cf86296dd0c68cd5cc286c9eef2d0c3b8b192b604ce9de20a17"},
+    {file = "coverage-7.6.4-cp312-cp312-win_amd64.whl", hash = "sha256:1032e178b76a4e2b5b32e19d0fd0abbce4b58e77a1ca695820d10e491fa32b08"},
+    {file = "coverage-7.6.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:023bf8ee3ec6d35af9c1c6ccc1d18fa69afa1cb29eaac57cb064dbb262a517f9"},
+    {file = "coverage-7.6.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0ac3d42cb51c4b12df9c5f0dd2f13a4f24f01943627120ec4d293c9181219ba"},
+    {file = "coverage-7.6.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8fe4984b431f8621ca53d9380901f62bfb54ff759a1348cd140490ada7b693c"},
+    {file = "coverage-7.6.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5fbd612f8a091954a0c8dd4c0b571b973487277d26476f8480bfa4b2a65b5d06"},
+    {file = "coverage-7.6.4-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dacbc52de979f2823a819571f2e3a350a7e36b8cb7484cdb1e289bceaf35305f"},
+    {file = "coverage-7.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dab4d16dfef34b185032580e2f2f89253d302facba093d5fa9dbe04f569c4f4b"},
+    {file = "coverage-7.6.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:862264b12ebb65ad8d863d51f17758b1684560b66ab02770d4f0baf2ff75da21"},
+    {file = "coverage-7.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5beb1ee382ad32afe424097de57134175fea3faf847b9af002cc7895be4e2a5a"},
+    {file = "coverage-7.6.4-cp313-cp313-win32.whl", hash = "sha256:bf20494da9653f6410213424f5f8ad0ed885e01f7e8e59811f572bdb20b8972e"},
+    {file = "coverage-7.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:182e6cd5c040cec0a1c8d415a87b67ed01193ed9ad458ee427741c7d8513d963"},
+    {file = "coverage-7.6.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a181e99301a0ae128493a24cfe5cfb5b488c4e0bf2f8702091473d033494d04f"},
+    {file = "coverage-7.6.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:df57bdbeffe694e7842092c5e2e0bc80fff7f43379d465f932ef36f027179806"},
+    {file = "coverage-7.6.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bcd1069e710600e8e4cf27f65c90c7843fa8edfb4520fb0ccb88894cad08b11"},
+    {file = "coverage-7.6.4-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99b41d18e6b2a48ba949418db48159d7a2e81c5cc290fc934b7d2380515bd0e3"},
+    {file = "coverage-7.6.4-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6b1e54712ba3474f34b7ef7a41e65bd9037ad47916ccb1cc78769bae324c01a"},
+    {file = "coverage-7.6.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:53d202fd109416ce011578f321460795abfe10bb901b883cafd9b3ef851bacfc"},
+    {file = "coverage-7.6.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:c48167910a8f644671de9f2083a23630fbf7a1cb70ce939440cd3328e0919f70"},
+    {file = "coverage-7.6.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cc8ff50b50ce532de2fa7a7daae9dd12f0a699bfcd47f20945364e5c31799fef"},
+    {file = "coverage-7.6.4-cp313-cp313t-win32.whl", hash = "sha256:b8d3a03d9bfcaf5b0141d07a88456bb6a4c3ce55c080712fec8418ef3610230e"},
+    {file = "coverage-7.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:f3ddf056d3ebcf6ce47bdaf56142af51bb7fad09e4af310241e9db7a3a8022e1"},
+    {file = "coverage-7.6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9cb7fa111d21a6b55cbf633039f7bc2749e74932e3aa7cb7333f675a58a58bf3"},
+    {file = "coverage-7.6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:11a223a14e91a4693d2d0755c7a043db43d96a7450b4f356d506c2562c48642c"},
+    {file = "coverage-7.6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a413a096c4cbac202433c850ee43fa326d2e871b24554da8327b01632673a076"},
+    {file = "coverage-7.6.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00a1d69c112ff5149cabe60d2e2ee948752c975d95f1e1096742e6077affd376"},
+    {file = "coverage-7.6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f76846299ba5c54d12c91d776d9605ae33f8ae2b9d1d3c3703cf2db1a67f2c0"},
+    {file = "coverage-7.6.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fe439416eb6380de434886b00c859304338f8b19f6f54811984f3420a2e03858"},
+    {file = "coverage-7.6.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0294ca37f1ba500667b1aef631e48d875ced93ad5e06fa665a3295bdd1d95111"},
+    {file = "coverage-7.6.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6f01ba56b1c0e9d149f9ac85a2f999724895229eb36bd997b61e62999e9b0901"},
+    {file = "coverage-7.6.4-cp39-cp39-win32.whl", hash = "sha256:bc66f0bf1d7730a17430a50163bb264ba9ded56739112368ba985ddaa9c3bd09"},
+    {file = "coverage-7.6.4-cp39-cp39-win_amd64.whl", hash = "sha256:c481b47f6b5845064c65a7bc78bc0860e635a9b055af0df46fdf1c58cebf8e8f"},
+    {file = "coverage-7.6.4-pp39.pp310-none-any.whl", hash = "sha256:3c65d37f3a9ebb703e710befdc489a38683a5b152242664b973a7b7b22348a4e"},
+    {file = "coverage-7.6.4.tar.gz", hash = "sha256:29fc0f17b1d3fea332f8001d4558f8214af7f1d87a345f3a133c901d60347c73"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cryptography"
 version = "43.0.3"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -1284,6 +1358,24 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "5.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "pytest-env"
 version = "1.1.5"
 description = "pytest plugin that allows you to add environment variables."
@@ -2082,4 +2174,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "6fd77cc1bf0b6e0642a56db715f71e10a419b993e020ede112d9fcf811db9710"
+content-hash = "6d78e1e9dff10d8d4c6d77398db557e52f4ae40cc5f974db0137cd6b3f44a5b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-env = "^1.1.5"
 pytest-mock = "^3.14.0"
 ruff = "^0.6.9"
 toml-sort = "^0.23.1"
+pytest-cov = "^5.0.0"
 
 [tool.pytest.ini_options]
 addopts = [
@@ -38,8 +39,11 @@ addopts = [
     "-p no:warnings",
 ]
 env = [
-    "AWS_REGION_NAME = eu-central-1",
     "DEBUG = True",
+
+    "AWS_REGION_NAME = eu-central-1",
+    "BASIC_AUTH_USERNAME = hello",
+    "BASIC_AUTH_PASSWORD = world",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ bpython = "^0.24"
 moto = {extras = ["dynamodb"], version = "^5.0.18"}
 mypy-boto3-dynamodb = "^1.35.24"
 pytest = "^8.3.3"
+pytest-cov = "^5.0.0"
 pytest-env = "^1.1.5"
 pytest-mock = "^3.14.0"
 ruff = "^0.6.9"
 toml-sort = "^0.23.1"
-pytest-cov = "^5.0.0"
 
 [tool.pytest.ini_options]
 addopts = [
@@ -39,11 +39,10 @@ addopts = [
     "-p no:warnings",
 ]
 env = [
-    "DEBUG = True",
-
     "AWS_REGION_NAME = eu-central-1",
-    "BASIC_AUTH_USERNAME = hello",
     "BASIC_AUTH_PASSWORD = world",
+    "BASIC_AUTH_USERNAME = hello",
+    "DEBUG = True",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import base64
 from typing import TYPE_CHECKING, Generator
 
 import boto3
@@ -17,6 +18,14 @@ from app.main import app
 @pytest.fixture(scope="session")
 def client() -> TestClient:
     return TestClient(app)
+
+
+@pytest.fixture(scope="session")
+def client_with_basic_auth(client) -> TestClient:
+    auth_string = base64.b64encode(f"{settings.basic_auth_username}:{settings.basic_auth_password}".encode()).decode()
+    headers = {"Authorization": f"Basic {auth_string}"}
+    client.headers.update(headers)
+    return client
 
 
 @pytest.fixture

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPBasicCredentials
+
+from app.dependencies import require_basic_auth
+
+
+class TestRequireBasicAuth:
+    def test_valid_basic_auth(self):
+        credentials = HTTPBasicCredentials(username="hello", password="world")
+        result = require_basic_auth(credentials)
+        assert result is None
+
+    def test_invalid_basic_auth(self):
+        credentials = HTTPBasicCredentials(username="oops", password="I, did it again")
+
+        with pytest.raises(HTTPException) as exc:
+            require_basic_auth(credentials)
+
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Invalid credentials"
+        assert exc.value.headers == {"WWW-Authenticate": "Basic"}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,16 @@
-def test_home(client):
-    response = client.get("/")
+class TestHomePage:
+    def test_success_default_url(self, client):
+        response = client.get("/")
 
-    assert response.status_code == 200
-    assert "URL Shortener" in response.text
+        assert "URL Shortener" in response.text
+        assert str(response.context["origin"]) == "http://testserver/"
+        assert response.context["frontend_assets_url"] == "/static/frontend"
+
+    def test_versioned_assets_cloudfront_url(self, client):
+        from app.config import settings
+
+        settings.frontend_assets_version = "202410291028_73bc2b9"
+        settings.aws_cloudfront_domain = "cdn.example.com"
+
+        response = client.get("/")
+        assert response.context["frontend_assets_url"] == "https://cdn.example.com/fus/v/202410291028_73bc2b9"


### PR DESCRIPTION
- added `require_basic_auth` as a dependency for listing all URLs endpoint. 
Later can be reused for other endpoints(e.g. stats with aggregated metrics)
- added `make testwithcoverage` command against the `app` folder to test total coverage (no less than 90% allowed, more to cover later)
- changed `BACKEND_PORT=8080` when launching `vite` app. That's a dockerized web service, which is launched by default with `compose up -d` anyyway. It's more convenient to develop frontend features with hot-reload from vite app, and API changes from backend port only